### PR TITLE
Enable github releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,7 @@ jobs:
       CF_API_KEY: ${{ secrets.CF_API_KEY }}
       #WOWI_API_TOKEN: ${{ secrets.WOWI_API_TOKEN }}
       #WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-      #GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  # "GITHUB_TOKEN" is a secret always provided to the workflow
-                                                 # for your own token, the name cannot start with "GITHUB_"
-
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}  
     # "steps" holds a list of all the steps needed to package and release our AddOn
     steps:
 


### PR DESCRIPTION
This PR enables github release to allow big wigs packager the creation of `release.json` as well as a proper release zip.
It aswell enables the creation of a default changelog.

`release.json` is used by WowUp to update addons.

I made a test release in my fork => https://github.com/sirux88/RaidFrameSettings/releases/tag/2.19.2