### PR TITLE
Add whitelist feature to the buff module

### DIFF
--- a/DB/DB.lua
+++ b/DB/DB.lua
@@ -87,6 +87,8 @@ local defaults = {
             Blacklist = {
                 --spellID = true
             },
+            Whitelist = {
+            },
         },
         AuraHighlight = {
             Config = {


### PR DESCRIPTION
This was requested in the comments on the add-on homepage:

https://www.curseforge.com/wow/addons/raid-frame-settings/comments

georbig #6299484 

could I set some key buffs which not from me shows up on the buff frame ?



![image](https://github.com/Slothpala/RaidFrameSettings/assets/3642914/0127ff8b-fbc3-40e7-bec0-33285ea7fb86)
![image](https://github.com/Slothpala/RaidFrameSettings/assets/3642914/2dad86cc-1115-46bc-afd6-1c62ef6f4fc3)
