### PR TITLE
Show buff timer in vanilla and bugfixes

### DIFF
--- a/Modules/Buffs_Classic.lua
+++ b/Modules/Buffs_Classic.lua
@@ -161,7 +161,11 @@ function Buffs:OnEnable()
     end
     self:HookFuncFiltered("DefaultCompactUnitFrameSetup", onFrameSetup)
 
-    local onSetBuff = function(buffFrame)
+    local onSetBuff = function(buffFrame, unit, index, filter)
+        local name, icon, count, debuffType, duration, expirationTime, unitCaster, canStealOrPurge, _, spellId, canApplyAura = UnitBuff(unit, index, filter)
+        if GetClassicExpansionLevel() < LE_EXPANSION_BURNING_CRUSADE then
+            CompactUnitFrame_UpdateCooldownFrame(buffFrame, expirationTime, duration, false)
+        end
         local cooldown = buffFrame.cooldown
         CDT:StartCooldownText(buffFrame.cooldown)
         cooldown:SetDrawEdge(frameOpt.edge)

--- a/RaidFrameSettings_Vanilla.toc
+++ b/RaidFrameSettings_Vanilla.toc
@@ -1,4 +1,4 @@
-## Interface: 11500
+## Interface: 11501
 ## Version: @project-version@
 ## Title: RaidFrameSettings
 ## Author: Slothpala

--- a/Roster.lua
+++ b/Roster.lua
@@ -22,7 +22,7 @@ end
 
 local function updateRoster()
     Roster = {}
-    local useRaid = ( IsInRaid() and not select(1,IsActiveBattlefieldArena()) ) or addonTable.isClassic --IsInRaid() returns true in arena even though we need party frame names
+    local useRaid = ( IsInRaid() and not select(1,IsActiveBattlefieldArena()) ) or addonTable.isWrath --IsInRaid() returns true in arena even though we need party frame names
     if useRaid then 
         if showSeparateGroups() then
             for i=1, 8 do


### PR DESCRIPTION
Blizzard has made the cooldown timer invisible on buffs before TBC. 
I don't know why, but I've changed it to show the timer.

```
function CompactUnitFrame_UpdateCooldownFrame(frame, expirationTime, duration, buff)
	if GetClassicExpansionLevel() < LE_EXPANSION_BURNING_CRUSADE and buff then
		return;
	end

	local enabled = expirationTime and expirationTime ~= 0;
	if enabled then
		local startTime = expirationTime - duration;
		CooldownFrame_Set(frame.cooldown, startTime, duration, true);
	else
		CooldownFrame_Clear(frame.cooldown);
	end
end
```

I also updated the version number and fixed the roster configuration. 
There are differences between vanilla and wrath.  
The roster issue is on the wrath side, but I didn't make it a separate PR because it's too minor a fix.