### PR TITLE
Include buffs from others when checking for missing auras

### DIFF
--- a/Modules/AuraHighlight.lua
+++ b/Modules/AuraHighlight.lua
@@ -61,7 +61,7 @@ local function updateAurasFull(frame)
         end
     end
     local function HandleHelpAura(aura)
-        if aura_missing_list[aura.spellId] and aura.sourceUnit == "player" then
+        if aura_missing_list[aura.spellId] then
             auraMap[frame].missing_list[aura.auraInstanceID] = aura.spellId
         end
     end
@@ -79,7 +79,7 @@ local function updateAurasIncremental(frame, updateInfo)
             if Bleeds[aura.spellId] and LCD:CanDispel("Bleed") then 
                 auraMap[frame].debuffs[aura.auraInstanceID] = "Bleed"
             end
-            if aura_missing_list[aura.spellId] and aura.sourceUnit == "player" then
+            if aura_missing_list[aura.spellId] then
                 auraMap[frame].missing_list[aura.auraInstanceID] = aura.spellId
             end
         end


### PR DESCRIPTION
Fixed missing auras sometimes being recognized as missing even if the party has the same class and already has the buff.

