### PR TITLE
Fixed font settings issues

### DIFF
--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -109,7 +109,7 @@ function Fonts:OnEnable()
         frame.name:ClearAllPoints()
         local res = frame.name:SetFont(Name.Font, Name.FontSize, Name.Outlinemode)
         if not res then
-            frame.name:SetFont(defaultFont, 10,"NONE")
+            frame.name:SetFont(defaultNameFont.font, defaultNameFont.height, "NONE")
         end
         frame.name:SetWidth((frame:GetWidth()))
         frame.name:SetJustifyH(Name.JustifyH)

--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -124,7 +124,7 @@ function Fonts:OnDisable()
         frame.name:SetShadowColor(fontObj:GetShadowColor())
         frame.name:SetShadowOffset(fontObj:GetShadowOffset())
         frame.name:ClearAllPoints()
-        frame.name:SetPoint("TOPLEFT", frame.roleIcon, "TOPRIGHT", 0, -1);
+        frame.name:SetPoint("TOPLEFT", frame.roleIcon, "TOPRIGHT", 0, -1)
         frame.name:SetPoint("TOPRIGHT", -3, -3);
         frame.name:SetJustifyH("LEFT");
         --Status
@@ -138,7 +138,7 @@ function Fonts:OnDisable()
         local componentScale = min(frameHeight / NATIVE_UNIT_FRAME_HEIGHT, frameWidth / NATIVE_UNIT_FRAME_WIDTH);
         local NATIVE_FONT_SIZE = 12
         local fontName, fontSize, fontFlags = frame.statusText:GetFont();
-        frame.statusText:SetFont(fontName, NATIVE_FONT_SIZE * componentScale, fontFlags);
+        frame.statusText:SetFont(fontName, NATIVE_FONT_SIZE * componentScale, fontFlags)
         frame.statusText:ClearAllPoints()
         frame.statusText:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 3, frameHeight / 3 - 2)
         frame.statusText:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -3, frameHeight / 3 - 2)

--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -20,51 +20,7 @@ local GetUnitName = GetUnitName
 local UnitClass = UnitClass
 local GetClassColor = GetClassColor
 
-local locale = GetLocale()
-local defaultNameFont = {
-    koKR = {
-        font = "Fonts\\FRIZQT__.TTF",
-        height = 10,
-    },
-    zhCN = {
-        font = "Fonts\\ARKai_T.TTF",
-        height = 11,
-    },
-    zhTW = {
-        font = "Fonts\\blei00d.TTF",
-        height = 15,
-    },
-    ruRU = {
-        font = "Fonts\\FRIZQT___CYR.TTF",
-        height = 15,
-    },
-    default = {
-        font = "Fonts\\FRIZQT__.TTF",
-        height = 10,
-    },
-}
-local defaultStatusFont = {
-    koKR = {
-        font = "Fonts\\FRIZQT__.TTF",
-        height = 12,
-    },
-    zhCN = {
-        font = "Fonts\\ARKai_T.TTF",
-        height = 12,
-    },
-    zhTW = {
-        font = "Fonts\\blei00d.TTF",
-        height = 15,
-    },
-    ruRU = {
-        font = "Fonts\\FRIZQT___CYR.TTF",
-        height = 15,
-    },
-    default = {
-        font = "Fonts\\FRIZQT__.TTF",
-        height = 12,
-    },
-}
+local fontObj = CreateFont("RaidFrameSettingsFont")
 
 function Fonts:OnEnable()
     local dbObj = RaidFrameSettings.db.profile.Fonts
@@ -109,8 +65,8 @@ function Fonts:OnEnable()
         frame.name:ClearAllPoints()
         local res = frame.name:SetFont(Name.Font, Name.FontSize, Name.Outlinemode)
         if not res then
-            local font = defaultNameFont[locale] or defaultNameFont.default
-            frame.name:SetFont(font.font, font.height, "NONE")
+            fontObj:SetFontObject("GameFontHighlightSmall")
+            frame.name:SetFont(fontObj:GetFont())
         end
         frame.name:SetWidth((frame:GetWidth()))
         frame.name:SetJustifyH(Name.JustifyH)
@@ -121,8 +77,8 @@ function Fonts:OnEnable()
         frame.statusText:ClearAllPoints()
         res = frame.statusText:SetFont(Status.Font, Status.FontSize, Status.Outlinemode)
         if not res then
-            local font = defaultStatusFont[locale] or defaultStatusFont.default
-            frame.name:SetFont(font.font, font.height, "NONE")
+            fontObj:SetFontObject("GameFontDisable")
+            frame.statusText:SetFont(fontObj:GetFont())
         end
         frame.statusText:SetWidth((frame:GetWidth()))
         frame.statusText:SetJustifyH(Status.JustifyH)
@@ -162,25 +118,31 @@ end
 function Fonts:OnDisable()
     local restoreFonts = function(frame)
         --Name
-        local font = defaultNameFont[locale] or defaultNameFont.default
-        frame.name:SetFont(font.font, font.height, "NONE")
+        fontObj:SetFontObject("GameFontHighlightSmall")
+        frame.name:SetFont(fontObj:GetFont())
+        frame.name:SetVertexColor(fontObj:GetTextColor())
+        frame.name:SetShadowColor(fontObj:GetShadowColor())
+        frame.name:SetShadowOffset(fontObj:GetShadowOffset())
+        frame.name:ClearAllPoints()
         frame.name:SetPoint("TOPLEFT", frame.roleIcon, "TOPRIGHT", 0, -1);
-        frame.name:SetPoint("TOPRIGHT", -3, -3)
+        frame.name:SetPoint("TOPRIGHT", -3, -3);
         frame.name:SetJustifyH("LEFT");
-        frame.name:SetVertexColor(1,1,1)
-        frame.name:SetShadowColor(0,0,0)
-        frame.name:SetShadowOffset(1,-1)
-     --Status
-        font = defaultStatusFont[locale] or defaultStatusFont.default
-        frame.name:SetFont(font.font, font.height, "NONE")
+        --Status
+        fontObj:SetFontObject("GameFontDisable")
+        frame.statusText:SetFont(fontObj:GetFont())
+        frame.statusText:SetVertexColor(fontObj:GetTextColor())
+        frame.statusText:SetShadowColor(fontObj:GetShadowColor())
+        frame.statusText:SetShadowOffset(fontObj:GetShadowOffset())
         local frameWidth = frame:GetWidth()
         local frameHeight = frame:GetHeight()
-        frame.statusText:SetFont(font.font, font.height, "NONE")
+        local componentScale = min(frameHeight / NATIVE_UNIT_FRAME_HEIGHT, frameWidth / NATIVE_UNIT_FRAME_WIDTH);
+        local NATIVE_FONT_SIZE = 12
+        local fontName, fontSize, fontFlags = frame.statusText:GetFont();
+        frame.statusText:SetFont(fontName, NATIVE_FONT_SIZE * componentScale, fontFlags);
+        frame.statusText:ClearAllPoints()
         frame.statusText:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 3, frameHeight / 3 - 2)
         frame.statusText:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -3, frameHeight / 3 - 2)
-        frame.statusText:SetVertexColor(0.5,0.5,0.5)
-        frame.statusText:SetShadowColor(0,0,0)
-        frame.statusText:SetShadowOffset(1,-1)
+        frame.statusText:SetHeight(12 * componentScale)
     end
     RaidFrameSettings:IterateRoster(restoreFonts)
 end

--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -20,6 +20,18 @@ local GetUnitName = GetUnitName
 local UnitClass = UnitClass
 local GetClassColor = GetClassColor
 
+local locale = GetLocale()
+local defaultFont = "Fonts\\FRIZQT__.TTF"
+if locale == "koKR" then
+    defaultFont = "Fonts\\2002.TTF"
+elseif locale == "zhCN" then
+    defaultFont = "Fonts\\ARKai_T.TTF"
+elseif locale == "zhTW" then
+    defaultFont = "Fonts\\blei00d.TTF"
+elseif locale == "ruRU" then
+    defaultFont = "Fonts\\FRIZQT___CYR.TTF"
+end
+
 function Fonts:OnEnable()
     local dbObj = RaidFrameSettings.db.profile.Fonts
     --Name
@@ -61,7 +73,10 @@ function Fonts:OnEnable()
     local function UpdateFont(frame)
         --Name
         frame.name:ClearAllPoints()
-        frame.name:SetFont(Name.Font, Name.FontSize, Name.Outlinemode)
+        local res = frame.name:SetFont(Name.Font, Name.FontSize, Name.Outlinemode)
+        if not res then
+            frame.name:SetFont(defaultFont, 10,"NONE")
+        end
         frame.name:SetWidth((frame:GetWidth()))
         frame.name:SetJustifyH(Name.JustifyH)
         frame.name:SetPoint(Name.Position, frame, Name.Position, Name.X_Offset, Name.Y_Offset )
@@ -108,7 +123,7 @@ end
 function Fonts:OnDisable()
     local restoreFonts = function(frame)
         --Name
-        frame.name:SetFont("Fonts\\FRIZQT__.TTF", 10,"NONE")
+        frame.name:SetFont(defaultFont, 10,"NONE")
         frame.name:SetPoint("TOPLEFT", frame.roleIcon, "TOPRIGHT", 0, -1);
         frame.name:SetPoint("TOPRIGHT", -3, -3)
         frame.name:SetJustifyH("LEFT");
@@ -116,7 +131,7 @@ function Fonts:OnDisable()
         --Status
         local frameWidth = frame:GetWidth()
         local frameHeight = frame:GetHeight()
-        frame.statusText:SetFont("Fonts\\FRIZQT__.TTF", 12,"NONE")
+        frame.statusText:SetFont(defaultFont, 12,"NONE")
         frame.statusText:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 3, frameHeight / 3 - 2)
         frame.statusText:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -3, frameHeight / 3 - 2)
         frame.statusText:SetVertexColor(0.5,0.5,0.5)

--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -21,16 +21,50 @@ local UnitClass = UnitClass
 local GetClassColor = GetClassColor
 
 local locale = GetLocale()
-local defaultFont = "Fonts\\FRIZQT__.TTF"
-if locale == "koKR" then
-    defaultFont = "Fonts\\2002.TTF"
-elseif locale == "zhCN" then
-    defaultFont = "Fonts\\ARKai_T.TTF"
-elseif locale == "zhTW" then
-    defaultFont = "Fonts\\blei00d.TTF"
-elseif locale == "ruRU" then
-    defaultFont = "Fonts\\FRIZQT___CYR.TTF"
-end
+local defaultNameFont = {
+    koKR = {
+        font = "Fonts\\FRIZQT__.TTF",
+        height = 10,
+    },
+    zhCN = {
+        font = "Fonts\\ARKai_T.TTF",
+        height = 11,
+    },
+    zhTW = {
+        font = "Fonts\\blei00d.TTF",
+        height = 15,
+    },
+    ruRU = {
+        font = "Fonts\\FRIZQT___CYR.TTF",
+        height = 15,
+    },
+    default = {
+        font = "Fonts\\FRIZQT__.TTF",
+        height = 10,
+    },
+}
+local defaultStatusFont = {
+    koKR = {
+        font = "Fonts\\FRIZQT__.TTF",
+        height = 12,
+    },
+    zhCN = {
+        font = "Fonts\\ARKai_T.TTF",
+        height = 12,
+    },
+    zhTW = {
+        font = "Fonts\\blei00d.TTF",
+        height = 15,
+    },
+    ruRU = {
+        font = "Fonts\\FRIZQT___CYR.TTF",
+        height = 15,
+    },
+    default = {
+        font = "Fonts\\FRIZQT__.TTF",
+        height = 12,
+    },
+}
 
 function Fonts:OnEnable()
     local dbObj = RaidFrameSettings.db.profile.Fonts
@@ -123,18 +157,25 @@ end
 function Fonts:OnDisable()
     local restoreFonts = function(frame)
         --Name
-        frame.name:SetFont(defaultFont, 10,"NONE")
+        local font = defaultNameFont[locale] or defaultNameFont.default
+        frame.name:SetFont(font.font, font.height, "NONE")
         frame.name:SetPoint("TOPLEFT", frame.roleIcon, "TOPRIGHT", 0, -1);
         frame.name:SetPoint("TOPRIGHT", -3, -3)
         frame.name:SetJustifyH("LEFT");
         frame.name:SetVertexColor(1,1,1)
-        --Status
+        frame.name:SetShadowColor(0,0,0)
+        frame.name:SetShadowOffset(1,-1)
+     --Status
+        font = defaultStatusFont[locale] or defaultStatusFont.default
+        frame.name:SetFont(font.font, font.height, "NONE")
         local frameWidth = frame:GetWidth()
         local frameHeight = frame:GetHeight()
-        frame.statusText:SetFont(defaultFont, 12,"NONE")
+        frame.statusText:SetFont(font.font, font.height, "NONE")
         frame.statusText:SetPoint("BOTTOMLEFT", frame, "BOTTOMLEFT", 3, frameHeight / 3 - 2)
         frame.statusText:SetPoint("BOTTOMRIGHT", frame, "BOTTOMRIGHT", -3, frameHeight / 3 - 2)
         frame.statusText:SetVertexColor(0.5,0.5,0.5)
+        frame.statusText:SetShadowColor(0,0,0)
+        frame.statusText:SetShadowOffset(1,-1)
     end
     RaidFrameSettings:IterateRoster(restoreFonts)
 end

--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -109,7 +109,7 @@ function Fonts:OnEnable()
         frame.name:ClearAllPoints()
         local res = frame.name:SetFont(Name.Font, Name.FontSize, Name.Outlinemode)
         if not res then
-            frame.name:SetFont(defaultNameFont.font, defaultNameFont.height, "NONE")
+            frame.name:SetFont(defaultNameFont.default.font, defaultNameFont.default.height, "NONE")
         end
         frame.name:SetWidth((frame:GetWidth()))
         frame.name:SetJustifyH(Name.JustifyH)

--- a/Modules/Fonts.lua
+++ b/Modules/Fonts.lua
@@ -109,7 +109,8 @@ function Fonts:OnEnable()
         frame.name:ClearAllPoints()
         local res = frame.name:SetFont(Name.Font, Name.FontSize, Name.Outlinemode)
         if not res then
-            frame.name:SetFont(defaultNameFont.default.font, defaultNameFont.default.height, "NONE")
+            local font = defaultNameFont[locale] or defaultNameFont.default
+            frame.name:SetFont(font.font, font.height, "NONE")
         end
         frame.name:SetWidth((frame:GetWidth()))
         frame.name:SetJustifyH(Name.JustifyH)
@@ -118,7 +119,11 @@ function Fonts:OnEnable()
         frame.name:SetShadowOffset(Advanced.x_offset,Advanced.y_offset)
         --Status
         frame.statusText:ClearAllPoints()
-        frame.statusText:SetFont(Status.Font, Status.FontSize, Status.Outlinemode)
+        res = frame.statusText:SetFont(Status.Font, Status.FontSize, Status.Outlinemode)
+        if not res then
+            local font = defaultStatusFont[locale] or defaultStatusFont.default
+            frame.name:SetFont(font.font, font.height, "NONE")
+        end
         frame.statusText:SetWidth((frame:GetWidth()))
         frame.statusText:SetJustifyH(Status.JustifyH)
         frame.statusText:SetPoint(Status.Position, frame, Status.Position, Status.X_Offset, Status.Y_Offset )


### PR DESCRIPTION
When the game first loads, a call to SetFont() without the font loaded may return a nil value.
After this point, if the font is loaded and you call SetFont() again with the same font, the actual font will not be set.
So I made it so that when the SetFont() call fails, it calls SetFont() again with the default font.
This resolved issue #27.

And when the Font module is disabled, I set it to a font that fits the alphabet.

Name = GameFontHighlightSmall
StatusText = GameFontDisable

```
<FontString name="$parentName" inherits="GameFontHighlightSmall" parentKey="name" wordwrap="false"/>
<FontString name="$parentStatusText" inherits="GameFontDisable" parentKey="statusText"/>
```
