### PR TITLE
Prevents duplicate script hooks

### DIFF
--- a/Utils/HookRegistry.lua
+++ b/Utils/HookRegistry.lua
@@ -31,16 +31,16 @@ function Hooks:HookScript(frame, handler, callback)
         callbacks[frame][handler] = {}
     end
     callbacks[frame][handler][self] = func
-    if not hooked[frame] or not hooked[frame][handler] then
+    if not hooked[frame] then
+        hooked[frame] = {}
+    end
+    if hooked[frame][handler] ~= frame:GetScript(handler) then
         frame:HookScript(handler, function(...)
             for key, callback in next, callbacks[frame][handler] do
                 callback(...)
             end
         end)
-        if not hooked[frame] then
-            hooked[frame] = {}
-        end
-        hooked[frame][handler] = true
+        hooked[frame][handler] = frame:GetScript(handler)
     end
     if not registry[self] then
         registry[self] = {}
@@ -176,6 +176,6 @@ function Hooks:RemoveHandler(frame, handler)
     if not hooked[frame] then
         return
     end
-    hooked[frame][handler] = nil
+    callbacks[frame][handler][self] = nil
 end
 


### PR DESCRIPTION
I noticed that when I set a new script with SetScript, the previously set hooked script disappears, and when I run GetScript after using HookScript, the address changes. I'm guessing that HookScript is probably creating a function that executes the existing script and executes the new script, and then does the SetScript processing.

So, if it was already hooked by RFS, I kept track of the address and prevented it from being hooked twice.

In the old way, disabling and enabling the AuraHighlight module was causing double hooking of the script.

But I still don't know much about addon development, so I'm not even sure if my fix is the right one. It would be great if you could review it.