### PR TITLE
Applying Coroutines to Show/Hide CDT and Aura Frames

### DIFF
--- a/Options/Options.lua
+++ b/Options/Options.lua
@@ -1028,7 +1028,7 @@ local options = {
                                             get = "GetStatus",
                                             set = "SetStatus",
                                             min = 0,
-                                            max = 10,
+                                            softMax = 10,
                                             step = 1,
                                             width = 1.4,
                                         },
@@ -1271,7 +1271,7 @@ local options = {
                                             get = "GetStatus",
                                             set = "SetStatus",
                                             min = 0,
-                                            max = 10,
+                                            softMax = 10,
                                             step = 1,
                                             width = 1.4,
                                         },
@@ -1558,6 +1558,21 @@ local options = {
             name = "Module Settings",
             type = "group",
             args = {
+                Test = {
+                    hidden = not isRetail,
+                    order = 0,
+                    name = "Aura Test",
+                    desc = "",
+                    type = "execute",
+                    func =
+                        function()
+                            local module
+                            module = RaidFrameSettings:GetModule("Buffs")
+                            module:test()
+                            module = RaidFrameSettings:GetModule("Debuffs")
+                            module:test()
+                        end,
+                },
                 RoleIcon = {
                     hidden = isVanilla or RoleIcon_disabled,
                     order = 1,

--- a/RaidFrameSettings.toc
+++ b/RaidFrameSettings.toc
@@ -28,6 +28,7 @@ Utils\ProfileSwitcher.lua
 Utils\CooldownText.lua
 Utils\Helper.lua
 Utils\HookRegistry.lua
+Utils\Queue.lua
 
 #Modules
 modules.xml

--- a/Roster.lua
+++ b/Roster.lua
@@ -27,15 +27,16 @@ local function UpdateRosterCache()
     Roster = {}
     local showSeparateGroups = ShowSeparateGroups()
     local useRaid = ( IsInRaid() and not select(1,IsActiveBattlefieldArena()) ) or ( addonTable.isClassic and not showSeparateGroups ) --IsInRaid() returns true in arena even though we need party frame names
-    if useRaid then 
-        if showSeparateGroups then
+    if true or useRaid then 
+        if true or showSeparateGroups then
             for i=1, 8 do
                 for j=1, 5 do
                     local frame = _G["CompactRaidGroup" ..i.. "Member" .. j .. "HealthBar"]
                     if frame then
                         frame = frame:GetParent()
                         if frame.unit then
-                            Roster[frame.unit] = frame
+                            -- Roster[frame.unit] = frame
+                            tinsert(Roster, frame)
                         end
                     end
                 end
@@ -45,7 +46,8 @@ local function UpdateRosterCache()
                 if frame then
                     frame = frame:GetParent()
                     if frame.unit then
-                        Roster[frame.unit] = frame
+                        -- Roster[frame.unit] = frame
+                        tinsert(Roster, frame)
                     end
                 end
             end
@@ -60,25 +62,29 @@ local function UpdateRosterCache()
                 end
             end
         end
-    else
+    end 
+    if true then
         for i=1, 5 do
             local frame = _G["CompactPartyFrameMember" ..i .. "HealthBar"]
             if frame then
                 frame = frame:GetParent()
                 local unit = frame.unit or ""
-                Roster[unit] = frame
+                -- Roster[unit] = frame
+                tinsert(Roster, frame)
             end
             local frame = _G["CompactPartyFramePet" ..i .. "HealthBar"]
             if frame then
                 frame = frame:GetParent()
                 if frame.unit then
-                    Roster[frame.unit] = frame
+                    -- Roster[frame.unit] = frame
+                    tinsert(Roster, frame)
                 end
             end
             local frame = _G["CompactArenaFrameMember" ..i .. "HealthBar"]
             if frame then
                 frame = frame:GetParent()
-                Roster[frame.unit] = frame
+                -- Roster[frame.unit] = frame
+                tinsert(Roster, frame)
             end
         end
     end

--- a/Utils/Helper.lua
+++ b/Utils/Helper.lua
@@ -133,3 +133,37 @@ function addon:GetPersonalCooldowns()
     end
     return defensives
 end
+
+function addon:MakeFakeAura(spellId, opt)
+    local spellName, _, icon = GetSpellInfo(spellId)
+    local aura = {
+        applications            = 0,         --number	
+        applicationsp           = nil,       --string? force show applications evenif it is 1
+        auraInstanceID          = -spellId,  --number	
+        canApplyAura            = false,     -- boolean	Whether or not the player can apply this aura.
+        charges                 = 0,         --number	
+        dispelName              = nil,       --string?	
+        duration                = 0,         --number	
+        expirationTime          = 0,         --number	
+        icon                    = icon,      --number	
+        isBossAura              = false,     --boolean	Whether or not this aura was applied by a boss.
+        isFromPlayerOrPlayerPet = false,     --boolean	Whether or not this aura was applied by a player or their pet.
+        isHarmful               = false,     --boolean	Whether or not this aura is a debuff.
+        isHelpful               = false,     --boolean	Whether or not this aura is a buff.
+        isNameplateOnly         = false,     --boolean	Whether or not this aura should appear on nameplates.
+        isRaid                  = false,     --boolean	Whether or not this aura meets the conditions of the RAID aura filter.
+        isStealable             = false,     --boolean	
+        maxCharges              = 0,         --number	
+        name                    = spellName, --string	The name of the aura.
+        nameplateShowAll        = false,     --boolean	Whether or not this aura should always be shown irrespective of any usual filtering logic.
+        nameplateShowPersonal   = false,     --boolean	
+        points                  = {},        --array	Variable returns - Some auras return additional values that typically correspond to something shown in the tooltip, such as the remaining strength of an absorption effect.	
+        sourceUnit              = nil,       --string?	Token of the unit that applied the aura.
+        spellId                 = spellId,   --number	The spell ID of the aura.
+        timeMod                 = 1,         --number	
+    }
+    if opt and type(opt) == "table" then
+        MergeTable(aura, opt)
+    end
+    return aura
+end

--- a/Utils/Queue.lua
+++ b/Utils/Queue.lua
@@ -1,0 +1,105 @@
+local _, addonTable = ...
+local addon = addonTable.RaidFrameSettings
+addonTable.Queue = {}
+local Queue = addonTable.Queue
+
+local C_Timer = C_Timer
+local SafePack = SafePack
+local SafeUnpack = SafeUnpack
+local tinsert = tinsert
+local debugprofilestop = debugprofilestop
+local debugstack = debugstack
+local geterrorhandler = geterrorhandler
+
+local coroutine = coroutine
+local pairs = pairs
+local next = next
+
+
+local queue = {}
+local pending = {}
+local ticker
+
+local co = coroutine.create(function()
+    while true do
+        if #queue == 0 then
+            coroutine.yield(0, queue)
+        end
+        for k, v in pairs(queue) do
+            v.func(SafeUnpack(v.args))
+            queue[k] = nil
+            coroutine.yield(k, queue)
+        end
+    end
+end)
+
+function Queue:add(func, ...)
+    tinsert(pending, {
+        func = func,
+        args = SafePack(...),
+    })
+end
+
+function Queue:run()
+    if ticker and not ticker:IsCancelled() then
+        return
+    end
+    for k, v in pairs(pending) do
+        tinsert(queue, v)
+        pending[k] = nil
+    end
+    local function run()
+        local start = debugprofilestop()
+        while debugprofilestop() - start < 1 do
+            if coroutine.status(co) ~= "dead" then
+                local ok, idx, queueLeft = coroutine.resume(co)
+                if not ok then
+                    geterrorhandler()(debugstack(co))
+                    ticker:Cancel()
+                    break
+                end
+                if next(queueLeft) == nil then
+                    for k, v in pairs(pending) do
+                        tinsert(queue, v)
+                        pending[k] = nil
+                    end
+                    if #queue == 0 then
+                        ticker:Cancel()
+                        break
+                    end
+                end
+            else
+                ticker:Cancel()
+                break
+            end
+        end
+    end
+    ticker = C_Timer.NewTicker(0, run)
+end
+
+function Queue:flush()
+    if ticker and not ticker:IsCancelled() then
+        ticker:Cancel()
+    end
+    while true do
+        if coroutine.status(co) ~= "dead" then
+            local ok, idx, queueLeft = coroutine.resume(co)
+            if not ok then
+                geterrorhandler()(debugstack(co))
+                break
+            end
+            if next(queueLeft) == nil then
+                for k, v in pairs(pending) do
+                    tinsert(queue, v)
+                    pending[k] = nil
+                end
+                if #queue == 0 then
+                    break
+                end
+            end
+        else
+            break
+        end
+    end
+end
+


### PR DESCRIPTION
This is not real PR.
I just want to share what I've been testing.

I tested applying a coroutine to the cooldown timer and show/hide of the aura frame to reduce lag.

The results were that the Cooldown Timer had a big effect, but the show/hide in aura, it actually decreased the FPS even more.
However, I'm hopeful that the lag was reduced at the sacrifice of more frames.

When applying the coroutine to the Cooldown Timer, I think it would be more effective to have it pause for 0.1~0.5 seconds after looping once and then loop again. 


1. https://youtu.be/bZSY3udZ1Sc - 19.6ms | Apply coroutines to CDTs
2. https://youtu.be/OF8lcL6N7WY - 24.3ms | Apply coroutines to CDTs and aura queue
3. https://youtu.be/5F1bgKxm0bE - 55.54ms | Original RFS
4. https://youtu.be/ss8-lFE6e6s - 57.3ms | Apply coroutines to aura queue



Oh, by the way, to create an extreme environment, I tested with 30 buffs and 15 debuffs in each frame. This would never happen in the real world.