### PR TITLE
Enable github release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,4 +19,5 @@ jobs:
         uses: BigWigsMods/packager@v2
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }} 
  


### PR DESCRIPTION
This PR enables github release to allow big wigs packager the creation of `release.json` as well as a proper release zip.

`release.json` is used by WowUp to update addons.

related to #11 