### PR TITLE
Ensure UnitCache always uses normalized realm names

### DIFF
--- a/UnitCache.lua
+++ b/UnitCache.lua
@@ -72,6 +72,7 @@ local function validate_cache(cache)
   return is_valid_name and is_valid_nickname and is_valid_realm and is_valid_class
 end
 
+local my_realm_name = GetRealmName():gsub("[%s%-]", "")
 
 ---@param guid string the GUID of the unit.
 ---@return table unit_cache the new unit cache entry or fallback.
@@ -92,7 +93,7 @@ local function new_unit_cache(guid)
     end
   end
   -- realm_name is an empty string if the player is from the same realm.
-  local realm_name = ( realm_name and #realm_name > 0 ) and realm_name or GetRealmName()
+  local realm_name = ( realm_name and #realm_name > 0 ) and realm_name or my_realm_name
   local name_and_realm_name = name .. "-" .. realm_name
   local cached_unit = {
     name = name,
@@ -133,7 +134,7 @@ update_frame:SetScript("OnEvent", function(self, event, ...)
     if unit_cache[guid] then
       local new_name, new_realm_name = UnitNameUnmodified(unit_token)
       if not new_realm_name then
-        new_realm_name = GetRealmName()
+        new_realm_name = my_realm_name
       end
       local new_name_and_realm_name = new_name .. "-" .. new_realm_name
       unit_cache[guid].name = new_name or ""


### PR DESCRIPTION
Hello, I'm author of [Rak Gaming Aliases](https://www.curseforge.com/wow/addons/rak-gaming-aliases), my addon changes names on RaidFrames according to the addon's settings.

I was asked to add support for RaidFrameSettings. After looking into code that I figured that I can fill `addon.db.profile.Nicknames` and then call `addon:UpdateNicknames()` to make my addon support RaidFrameSettings. 

The problem that I run into is that UnitCache uses inconsistent realm notation, for players on the same realm it uses `GetRealmName()` which is different from `GetPlayerInfoByGUID` and `UnitNameUnmodified`, latter 2 use normalized realm notation which doesn't include any spaces and `-` hyphens. This results in possible mismatches between `new_name_and_realm_name` and `addon.db.profile.Nicknames`'s keys for players on the same realm.

There is 2 options how to get normalized realm name
1. Use `GetNormalizedRealmName`
2. Use `GetRealmName` and `gsub` to remove spaces and `-` hyphens

`GetNormalizedRealmName` is known for possible nil returns early in the loading process and during loading between instances so my PR uses second option.